### PR TITLE
Feature counting randomization

### DIFF
--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -121,7 +121,7 @@ class Counting(commands.Cog):
 			# await asyncio.gather(thread_func())
 			if self.MIN_CNTR < timeout_minutes and self.c_status:
 				if self.MIN_CNTR == 0 and random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
-					self.c_status = False
+					self.MIN_CNTR = timeout_minutes
 					continue
 				print("BEFORE ASYNCIO to_thread CALL")
 				await asyncio.to_thread(self.counting_1minute_loop)

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -257,6 +257,8 @@ class Counting(commands.Cog):
 						self.counting_LOCK.notify()
 						self.counting_LOCK.release()
 						self.c_status = True
+						self.timeout_minutes = random.randint(1,10)
+						print(f"timeout_minutes: {self.timeout_minutes}")
 
 					else:
 						self.counting_sem.release() #release sem lock

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -95,9 +95,6 @@ class Counting(commands.Cog):
 
 			self.timeout_minutes = random.randint(1,10)
 			print(f"timeout_minutes: {self.timeout_minutes}")
-			if random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
-				self.MIN_CNTR = self.timeout_minutes
-				# continue
 			
 		elif not ret_lock:
 			print("Timeout!")
@@ -127,9 +124,15 @@ class Counting(commands.Cog):
 		while not self.bot.is_closed():
 			# await asyncio.gather(thread_func())
 			if self.MIN_CNTR < self.timeout_minutes and self.c_status:
-				# if self.MIN_CNTR == 0 and random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
-				# 	self.MIN_CNTR = self.timeout_minutes
-				# 	continue
+				print("prob", prob := random.random())
+				if self.MIN_CNTR == 0 and prob > 0.33:	# 66% chance for bot to immediately send a counting number after user input
+					await self.bot_counting_number()
+					print("AUTO1: counting number has been set to", self.counting_number)
+					self.c_status = False	# set status to false so this clause cant run again til successful user number
+					self.timeout_minutes = random.randint(1,10)	# get a new timeout to wait
+					print(f"timeout_minutes: {self.timeout_minutes}")
+					continue
+
 				print("BEFORE ASYNCIO to_thread CALL")
 				await asyncio.to_thread(self.counting_1minute_loop)
 				print("AFTER ASYNCIO to_thread CALL")
@@ -140,7 +143,7 @@ class Counting(commands.Cog):
 			
 			else:	# if timoput_minutes minutes has passed, have bot send a number if didnt send one since last user number
 				await self.bot_counting_number()
-				print("AUTO: counting number has been set to", self.counting_number)
+				print("AUTO2: counting number has been set to", self.counting_number)
 				self.MIN_CNTR = 0	# reset MIN_CNTR back to zero
 				self.c_status = False	# set status to false so this clause cant run again til successful user number
 				self.timeout_minutes = random.randint(1,10)	# get a new timeout to wait

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -97,7 +97,7 @@ class Counting(commands.Cog):
 			print(f"timeout_minutes: {self.timeout_minutes}")
 			if random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
 				self.MIN_CNTR = self.timeout_minutes
-				continue
+				# continue
 			
 		elif not ret_lock:
 			print("Timeout!")

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -114,14 +114,14 @@ class Counting(commands.Cog):
 
 		await self.bot.wait_until_ready()
 
-		timeout_minutes = random.randint(1,10)
+		self.timeout_minutes = random.randint(1,10)
 		# counting_LOCK.acquire()
 		# counting_LOCK.wait() # wait until successful number sent by user, will notify and continue on.
 		while not self.bot.is_closed():
 			# await asyncio.gather(thread_func())
-			if self.MIN_CNTR < timeout_minutes and self.c_status:
+			if self.MIN_CNTR < self.timeout_minutes and self.c_status:
 				if self.MIN_CNTR == 0 and random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
-					self.MIN_CNTR = timeout_minutes
+					self.MIN_CNTR = self.timeout_minutes
 					continue
 				print("BEFORE ASYNCIO to_thread CALL")
 				await asyncio.to_thread(self.counting_1minute_loop)
@@ -136,8 +136,8 @@ class Counting(commands.Cog):
 				print("AUTO: counting number has been set to", self.counting_number)
 				self.MIN_CNTR = 0	# reset MIN_CNTR back to zero
 				self.c_status = False	# set status to false so this clause cant run again til successful user number
-				timeout_minutes = random.randint(1,10)	# get a new timeout to wait
-				print(f"timeout_minutes: {timeout_minutes}")
+				self.timeout_minutes = random.randint(1,10)	# get a new timeout to wait
+				print(f"timeout_minutes: {self.timeout_minutes}")
 
 			print(f"MIN_CNTR: {self.MIN_CNTR} -- {time.time()-start}")
 

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -81,8 +81,6 @@ class Counting(commands.Cog):
 		>>	otherwise condition lock timeouts and MIN_CNTR increments
 	"""
 	def counting_1minute_loop(self):
-		# global MIN_CNTR
-		# global counting_LOCK
 
 		self.counting_LOCK.acquire()
 		print("about to wait")
@@ -139,13 +137,13 @@ class Counting(commands.Cog):
 				self.MIN_CNTR = 0	# reset MIN_CNTR back to zero
 				self.c_status = False	# set status to false so this clause cant run again til successful user number
 				timeout_minutes = random.randint(1,10)	# get a new timeout to wait
+				print(f"timeout_minutes: {timeout_minutes}")
 
 			print(f"MIN_CNTR: {self.MIN_CNTR} -- {time.time()-start}")
 
 
 	@commands.Cog.listener()
 	async def on_ready(self):
-		# global on_ready_status
 		
 		if self.on_ready_status: # this should only run once, especially when the API disconnects and reconnects
 			self.on_ready_status = False

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -120,7 +120,8 @@ class Counting(commands.Cog):
 
 		await self.bot.wait_until_ready()
 
-		print("timeout_minutes:", self.timeout_minutes := random.randint(1,10))
+		self.timeout_minutes = random.randint(1,10)
+		print("timeout_minutes:", self.timeout_minutes)
 		# counting_LOCK.acquire()
 		# counting_LOCK.wait() # wait until successful number sent by user, will notify and continue on.
 		while not self.bot.is_closed():

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -138,7 +138,7 @@ class Counting(commands.Cog):
 				print("AFTER ASYNCIO to_thread CALL")
 			
 			elif not self.c_status: 
-				await asyncio.sleep(15)
+				await asyncio.sleep(1)
 				continue
 			
 			else:	# if timoput_minutes minutes has passed, have bot send a number if didnt send one since last user number

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -92,6 +92,12 @@ class Counting(commands.Cog):
 			print("########### Notified before timeout!")
 			self.MIN_CNTR = 0
 			print(f"MIN_CNTR RESET TO {self.MIN_CNTR}")
+
+			self.timeout_minutes = random.randint(1,10)
+			print(f"timeout_minutes: {self.timeout_minutes}")
+			if random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
+				self.MIN_CNTR = self.timeout_minutes
+				continue
 			
 		elif not ret_lock:
 			print("Timeout!")
@@ -114,15 +120,15 @@ class Counting(commands.Cog):
 
 		await self.bot.wait_until_ready()
 
-		self.timeout_minutes = random.randint(1,10)
+		print("timeout_minutes:", self.timeout_minutes := random.randint(1,10))
 		# counting_LOCK.acquire()
 		# counting_LOCK.wait() # wait until successful number sent by user, will notify and continue on.
 		while not self.bot.is_closed():
 			# await asyncio.gather(thread_func())
 			if self.MIN_CNTR < self.timeout_minutes and self.c_status:
-				if self.MIN_CNTR == 0 and random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
-					self.MIN_CNTR = self.timeout_minutes
-					continue
+				# if self.MIN_CNTR == 0 and random.random() > 0.33:	# 66% chance for bot to immediately send a counting number after user input
+				# 	self.MIN_CNTR = self.timeout_minutes
+				# 	continue
 				print("BEFORE ASYNCIO to_thread CALL")
 				await asyncio.to_thread(self.counting_1minute_loop)
 				print("AFTER ASYNCIO to_thread CALL")
@@ -257,8 +263,6 @@ class Counting(commands.Cog):
 						self.counting_LOCK.notify()
 						self.counting_LOCK.release()
 						self.c_status = True
-						self.timeout_minutes = random.randint(1,10)
-						print(f"timeout_minutes: {self.timeout_minutes}")
 
 					else:
 						self.counting_sem.release() #release sem lock


### PR DESCRIPTION
Added randomization for when bot sends a counting number to #counting channel, ranges from 1-10 minutes.
Bot also may send a counting number immediately (66% chance of doing so) after a user sends a successful counting number.