### PR TITLE
Replace hardcoded Discord IDs with environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,13 @@
 # environment variables defined inside a .env file
 
-BOT_KEY = # add bot's token here as string (in quotes "...")
-LOG_CHANNEL = # add logging channel id here
+BOT_KEY = # Bot Token here as string (in quotes "...")
+LOG_CHANNEL = # Logging Channel ID
+STARTUP_CHANNEL = # Startup Channel ID
+CLASS_SUB_CHANNEL = # Class Subscription Channel ID
+GUILD_ID = # Guild ID
+CLASS_ANNOUNCEMENTS = # Class Announcement Channel ID
+STAFF_LOG_CHANNEL = # Staff Log Channel ID
+BOT_ID = # Bot User ID
+CATEGORIES = # Categories Channel IDs as someChannelID, otherChannelID, ...
+COUNTING_CHANNEL = # Counting Channel ID
+BOT_CHANNEL = # Bot Commands Channel ID

--- a/cogs/background.py
+++ b/cogs/background.py
@@ -37,7 +37,7 @@ class Background(commands.Cog):
 					"Warning_Msg": string.Template("**$class_name HOMEWORK REMINDER:** `$class_obj` is due in less then **3 hours**!! $class_role_mention")
 				}
 		}
-		self.class_sub_channel_id = 618210352341188618
+		self.class_sub_channel_id = int(os.getenv("CLASS_SUB_CHANNEL"))
 		self.sem = threading.Semaphore(1) # used to prevent background task from restarting before previous one finishes
 
 
@@ -57,7 +57,7 @@ class Background(commands.Cog):
 		Helper fuction to udpate the serer stats of number of members, excluding bots, in the server/guild
 	"""
 	async def update_guild_member_count(self):
-		psu_discord = self.bot.get_guild(575004997327126551)
+		psu_discord = self.bot.get_guild(int(os.getenv("GUILD_ID")))
 
 		f = lambda x : x.bot == False
 
@@ -87,7 +87,7 @@ class Background(commands.Cog):
 		BLACKLIST = ["Admin","GiveawayBot","Bots","Mod","dabBot","Simple Poll","Groovy"]
 		# @everyone is position 0
 
-		psu_discord = self.bot.get_guild(575004997327126551)
+		psu_discord = self.bot.get_guild(int(os.getenv("GUILD_ID")))
 		raw_roles = psu_discord.roles
 
 		f = lambda r : r.name not in BLACKLIST + ['@everyone']
@@ -133,11 +133,11 @@ class Background(commands.Cog):
 					data = {
 						"class_name": a[1],
 						"class_obj": a[3],
-						"class_role_mention": {discord.utils.get(self.bot.get_guild(575004997327126551).roles, id=int(a[0])).mention}
+						"class_role_mention": {discord.utils.get(self.bot.get_guild(int(os.getenv("GUILD_ID"))).roles, id=int(a[0])).mention}
 					}
 
 					# this will sub in data values into the $-placeholders by matching dictionary keys to placeholder names
-					m = await self.bot.get_channel(618818304936640533).send(value["Warning_Msg"].substitute(data))
+					m = await self.bot.get_channel(int(os.getenv("CLASS_ANNOUNCEMENTS"))).send(value["Warning_Msg"].substitute(data))
 
 					await m.add_reaction(emoji="🖕")
 					my_cursor.execute("DELETE FROM %s WHERE ID = %s", (table, a[0],)) #delete from table

--- a/cogs/counting.py
+++ b/cogs/counting.py
@@ -13,7 +13,9 @@ import mysqlConnection_local as sql # mysql file
 import traceback
 import pytz
 import threading
+from dotenv import load_dotenv
 
+load_dotenv() # adds environment variables to current environment
 
 """
 	This cog is for commands dealing with counting
@@ -57,7 +59,7 @@ class Counting(commands.Cog):
 		return commands.check(predicate)
 
 	"""
-		Check for commands, returns True if message not from bot (id: 618200495277867110)
+		Check for commands, returns True if message not from bot
 		>>	https://discordpy.readthedocs.io/en/stable/ext/commands/commands.html#checks
 	"""
 	def is_not_bot():
@@ -76,7 +78,7 @@ class Counting(commands.Cog):
 		
 		self.counting_number = self.counting_number + 1
 		self.counting_number_userId = 1234
-		await self.bot.get_channel(715963289494093845).send("{0:b}".format(self.counting_number)) # bot sends counting number in binary
+		await self.bot.get_channel(int(os.getenv("COUNTING_CHANNEL"))).send("{0:b}".format(self.counting_number)) # bot sends counting number in binary
 
 	"""
 		1 minute loop for counting
@@ -173,7 +175,7 @@ class Counting(commands.Cog):
 				self.counting_number = int(data[0][1]) # set global variables
 				self.counting_number_userId = str(data[0][0]) 
 
-				counting_msgs = [message async for message in self.bot.get_channel(715963289494093845).history(limit=30)]
+				counting_msgs = [message async for message in self.bot.get_channel(int(os.getenv("COUNTING_CHANNEL"))).history(limit=30)]
 				for c_m in counting_msgs:
 					try:
 						number_msg = int(c_m.content, 2) # checks if msg is a valid binary number
@@ -214,8 +216,8 @@ class Counting(commands.Cog):
 	@commands.Cog.listener()
 	async def on_message(self, message: discord.Message):
 		author, channel = message.author, message.channel
-	
-		if channel.id == 715963289494093845 and author.id != 618200495277867110:
+
+		if channel.id == int(os.getenv("COUNTING_CHANNEL")) and author.id != int(os.getenv("BOT_ID")): # if message is in #counting channel and not from bot
 			try:
 				number_sent = int(message.content, 2) # checks if msg is a valid binary number
 				

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -55,7 +55,7 @@ class Logging(commands.Cog):
 		Helper fuction to udpate the serer stats of number of members, excluding bots, in the server/guild
 	"""
 	async def update_guild_member_count(self):
-		psu_discord = self.bot.get_guild(575004997327126551)
+		psu_discord = self.bot.get_guild(int(os.getenv("GUILD_ID")))
 
 		f = lambda x : x.bot == False
 
@@ -85,7 +85,7 @@ class Logging(commands.Cog):
 		BLACKLIST = ["Admin","GiveawayBot","Bots","Mod","dabBot","Simple Poll","Groovy"]
 		# @everyone is position 0
 
-		psu_discord = self.bot.get_guild(575004997327126551)
+		psu_discord = self.bot.get_guild(int(os.getenv("GUILD_ID")))
 		raw_roles = psu_discord.roles
 
 		f = lambda r : r.name not in BLACKLIST + ['@everyone']
@@ -116,7 +116,7 @@ class Logging(commands.Cog):
 		print("{} left the server".format(member.name))
 		await self.reorder_channels()
 
-		await self.bot.get_channel(618204101666406402).send("{} left the server 🙁.".format(member.name))
+		await self.bot.get_channel(int(os.getenv("LOG_CHANNEL"))).send("{} left the server 🙁.".format(member.name))
 		est = pytz.timezone('US/Eastern')
 
 		possessed_roles = ", ".join([r.name for r in member.roles])
@@ -144,7 +144,7 @@ class Logging(commands.Cog):
 		print("{} joined the server".format(member.name))
 
 		try:
-			await member.send("Welcome to the Penn State CS/CE/EE Server!\nHead on over to <#618210352341188618> to join one of the classes listed there.\nIf a certain class isn't listed there, you can create a group chat for that certain class by doing `!create` in <#618205441540882451> to get started.")
+			await member.send("Welcome to the Penn State CS/CE/EE Server!\nHead on over to <#{}}> to join one of the classes listed there.\nIf a certain class isn't listed there, you can create a group chat for that certain class by doing `!create` in <#{}> to get started.".format(os.getenv("CLASS_SUB_CHANNEL"), os.getenv("BOT_CHANNEL")))
 			print("DM'd {}".format(member.name))
 		except Exception:
 			print("Could not DM {}".format(member.name))
@@ -189,7 +189,7 @@ class Logging(commands.Cog):
 
 			counting_number = await self.get_counting_number()
 			# Counting channel check
-			if msg.channel.id == 715963289494093845:
+			if msg.channel.id == int(os.getenv("COUNTING_CHANNEL")):
 				counting_number = await self.get_counting_number()
 				print(msg.content, self.int_to_binary(counting_number))
 
@@ -247,7 +247,7 @@ class Logging(commands.Cog):
 			await staff_log_channel.send(embed=em)
 
 		# Counting channel check
-		if before.channel.id == 715963289494093845:
+		if before.channel.id == int(os.getenv("COUNTING_CHANNEL")):
 			l_msg = [message async for message in await before.channel.history(limit=1)]
 			print(before.id, l_msg[0].id)
 			if before.id == l_msg[0].id:

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class PSU_Bot(commands.Bot): # inherits discord.commands class
 		print(f"Logged in as {self.user.name}:{self.user.id}")
 		# print(vars(self))
 		try:
-			await self.get_channel(795781887603114034).send("PSU EECS bot online!")
+			await self.get_channel(int(os.getenv("STARTUP_CHANNEL"))).send("PSU EECS bot online!")
 		except AttributeError:
 			pass
 		self.print_commands()


### PR DESCRIPTION
### Description
- Removed hardcoded IDs for guilds, channels, and bot users.
- Improved flexibility for multi-server deployments.
- Improved security, maintainability, and portability.

### Testing Checklist:
- [x] Verified .env loads correctly
- [ ] Confirmed all commands (!join, !leave, !create) work as expected
- [x] Checked that all channel IDs map to the right Discord channels
- [x] Confirmed startup message sends correctly


### Further Possible Improvements:
1. Consider adding runtime validation for .env variables
2. Move load_dotenv() to a singular global entry point within main.py for cleanup
